### PR TITLE
Update to Eclipse RDF4J Sesame

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 ext {
 	projectDescription	= "Complexible: OpenRdf Utility classes"
 	projectUrl			= "https://github.com/mhgrove/cp-openrdf-utils"
-	sesameVersion = "4.0.0"
+	sesameRdf4jVersion = "2.2.2"
 }
 
 subprojects {
@@ -84,9 +84,9 @@ task javadocs(type: Javadoc) {
 	configure(options) {
 		windowTitle "${core.archivesBaseName}-${core.version} API"
 		docTitle "${core.archivesBaseName}-${core.version}"
-		bottom "Copyright &#169; 2010-2016 Complexible. All Rights Reserved."
+		bottom "Copyright &#169; 2010-2018 Complexible. All Rights Reserved."
 		links "http://docs.oracle.com/javase/8/docs/api/",
 			  "http://docs.guava-libraries.googlecode.com/git-history/v18.0/javadoc/",
-			  "http://rdf4j.org/doc/4/apidocs/"
+			  "http://docs.rdf4j.org/javadoc/latest/"
 	}
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,5 @@
 group = "com.complexible.common"
-version = "4.0.1"
+version = "4.0.3"
 archivesBaseName = "cp-openrdf-utils"
 
 dependencies {
@@ -7,19 +7,18 @@ dependencies {
 		exclude group: "com.google.code.findbugs"
 	}
 
-	compile "org.openrdf.sesame:sesame-rio:${sesameVersion}@pom"
-	compile "org.openrdf.sesame:sesame-rio-turtle:$sesameVersion"
-	
-	compile "org.openrdf.sesame:sesame-model:$sesameVersion"
-	compile "org.openrdf.sesame:sesame-query:$sesameVersion"
-	compile "org.openrdf.sesame:sesame-queryalgebra-model:$sesameVersion"
-	compile "org.openrdf.sesame:sesame-queryparser-sparql:$sesameVersion"
-	compile "org.openrdf.sesame:sesame-queryresultio-api:$sesameVersion"
-	compile "org.openrdf.sesame:sesame-repository-api:$sesameVersion"
-	compile "org.openrdf.sesame:sesame-sail-api:$sesameVersion"
+	compile "org.eclipse.rdf4j:rdf4j-rio:${sesameRdf4jVersion}@pom"
+	compile "org.eclipse.rdf4j:rdf4j-rio-turtle:$sesameRdf4jVersion"
+	compile "org.eclipse.rdf4j:rdf4j-model:$sesameRdf4jVersion"
+	compile "org.eclipse.rdf4j:rdf4j-query:$sesameRdf4jVersion"
+	compile "org.eclipse.rdf4j:rdf4j-queryalgebra-model:$sesameRdf4jVersion"
+	compile "org.eclipse.rdf4j:rdf4j-queryparser-sparql:$sesameRdf4jVersion"
+	compile "org.eclipse.rdf4j:rdf4j-queryresultio-api:$sesameRdf4jVersion"
+	compile "org.eclipse.rdf4j:rdf4j-repository-api:$sesameRdf4jVersion"
+	compile "org.eclipse.rdf4j:rdf4j-sail-api:$sesameRdf4jVersion"
 
-	testCompile "org.openrdf.sesame:sesame-repository-sail:$sesameVersion"
-	testCompile "org.openrdf.sesame:sesame-sail-memory:$sesameVersion"
+	testCompile "org.eclipse.rdf4j:rdf4j-repository-sail:$sesameRdf4jVersion"
+	testCompile "org.eclipse.rdf4j:rdf4j-sail-memory:$sesameRdf4jVersion"
 }
 
 configurations {

--- a/core/main/src/com/complexible/common/openrdf/model/ConstrainedModel.java
+++ b/core/main/src/com/complexible/common/openrdf/model/ConstrainedModel.java
@@ -16,14 +16,15 @@
 package com.complexible.common.openrdf.model;
 
 import java.util.Collection;
-
 import java.util.function.Predicate;
-import org.openrdf.model.IRI;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Model;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.Value;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
  * <p>A {@link Model} which has a {@link Predicate constraint} placed upon which statements can be added to the Model.</p>
@@ -91,16 +92,15 @@ public final class ConstrainedModel extends DelegatingModel {
 	 * {@inheritDoc}
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
 	public boolean add(final Resource theResource, final IRI theURI, final Value theValue, final Resource... theContexts) {
 
 		if (theContexts == null || theContexts.length == 0) {
-			return add(getValueFactory().createStatement(theResource, theURI, theValue));
+			return add(SimpleValueFactory.getInstance().createStatement(theResource, theURI, theValue));
 		}
 		else {
 			boolean aAdded = true;
 			for (Resource aCxt : theContexts) {
-				aAdded |= add(getValueFactory().createStatement(theResource, theURI, theValue, aCxt));
+				aAdded |= add(SimpleValueFactory.getInstance().createStatement(theResource, theURI, theValue, aCxt));
 			}
 
 			return aAdded;

--- a/core/main/src/com/complexible/common/openrdf/model/DelegatingModel.java
+++ b/core/main/src/com/complexible/common/openrdf/model/DelegatingModel.java
@@ -24,17 +24,17 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import org.openrdf.model.BNode;
-import org.openrdf.model.IRI;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Model;
-import org.openrdf.model.Namespace;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.util.ModelException;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.util.ModelException;
 
 /**
  * <p></p>

--- a/core/main/src/com/complexible/common/openrdf/model/ModelIO.java
+++ b/core/main/src/com/complexible/common/openrdf/model/ModelIO.java
@@ -31,16 +31,16 @@ import java.util.Optional;
 import com.complexible.common.openrdf.util.ModelBuildingRDFHandler;
 import com.complexible.common.openrdf.util.RDFByteSource;
 import com.google.common.base.Charsets;
-import org.openrdf.model.Model;
-import org.openrdf.model.Statement;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.rio.RDFHandler;
-import org.openrdf.rio.RDFHandlerException;
-import org.openrdf.rio.RDFParseException;
-import org.openrdf.rio.RDFParser;
-import org.openrdf.rio.RDFWriter;
-import org.openrdf.rio.Rio;
-import org.openrdf.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandler;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 
 /**
  * <p>Support for IO for {@link Model models}/</p>

--- a/core/main/src/com/complexible/common/openrdf/model/Models2.java
+++ b/core/main/src/com/complexible/common/openrdf/model/Models2.java
@@ -18,18 +18,18 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import info.aduna.iteration.Iteration;
-import info.aduna.iteration.Iterations;
-import org.openrdf.model.IRI;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Model;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.LinkedHashModel;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.model.vocabulary.RDF;
-import org.openrdf.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.common.iteration.Iteration;
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 
 /**
  * <p>Additional {@link Model} utilities</p>

--- a/core/main/src/com/complexible/common/openrdf/model/Statements.java
+++ b/core/main/src/com/complexible/common/openrdf/model/Statements.java
@@ -20,16 +20,16 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.openrdf.model.IRI;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.Value;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.model.util.Literals;
-import org.openrdf.model.vocabulary.XMLSchema;
-import org.openrdf.rio.turtle.TurtleUtil;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.rio.turtle.TurtleUtil;
 
 /**
  * <p>Some common Function implementations for working with Statements</p>

--- a/core/main/src/com/complexible/common/openrdf/query/AbstractBooleanQueryResultWriter.java
+++ b/core/main/src/com/complexible/common/openrdf/query/AbstractBooleanQueryResultWriter.java
@@ -18,15 +18,15 @@ package com.complexible.common.openrdf.query;
 import java.io.IOException;
 import java.util.List;
 
-import org.openrdf.query.BindingSet;
-import org.openrdf.query.QueryResultHandlerException;
-import org.openrdf.query.TupleQueryResultHandlerException;
-import org.openrdf.query.resultio.BooleanQueryResultFormat;
-import org.openrdf.query.resultio.BooleanQueryResultWriter;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryResultHandlerException;
+import org.eclipse.rdf4j.query.TupleQueryResultHandlerException;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.BooleanQueryResultWriter;
 
 /**
  * <p>{@link BooleanQueryResultWriter} base for creating custom writer implementations which throws {@link UnsupportedOperationException}
- * exceptions for the non-boolean result format methods which are incorrectly in the {@link org.openrdf.query.resultio.QueryResultWriter} interface.</p>
+ * exceptions for the non-boolean result format methods which are incorrectly in the {@link org.eclipse.rdf4j.query.resultio.QueryResultWriter} interface.</p>
  *
  * @author  Michael Grove
  * @since   1.0

--- a/core/main/src/com/complexible/common/openrdf/query/AbstractQueryResultWriter.java
+++ b/core/main/src/com/complexible/common/openrdf/query/AbstractQueryResultWriter.java
@@ -19,11 +19,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.openrdf.query.QueryResultHandlerException;
-import org.openrdf.query.resultio.QueryResultFormat;
-import org.openrdf.query.resultio.QueryResultWriter;
-import org.openrdf.rio.RioSetting;
-import org.openrdf.rio.WriterConfig;
+import org.eclipse.rdf4j.query.QueryResultHandlerException;
+import org.eclipse.rdf4j.query.resultio.QueryResultFormat;
+import org.eclipse.rdf4j.query.resultio.QueryResultWriter;
+import org.eclipse.rdf4j.rio.RioSetting;
+import org.eclipse.rdf4j.rio.WriterConfig;
 
 /**
  * <p>More useful base for creating custom {@link QueryResultWriter} implementations.

--- a/core/main/src/com/complexible/common/openrdf/query/BooleanQueryResult.java
+++ b/core/main/src/com/complexible/common/openrdf/query/BooleanQueryResult.java
@@ -15,10 +15,10 @@
 
 package com.complexible.common.openrdf.query;
 
-import org.openrdf.query.QueryResult;
+import org.eclipse.rdf4j.query.QueryResult;
 
 /**
- * <p>An analog to {@link org.openrdf.query.TupleQueryResult} and {@link org.openrdf.query.GraphQueryResult},
+ * <p>An analog to {@link org.eclipse.rdf4j.query.TupleQueryResult} and {@link org.eclipse.rdf4j.query.GraphQueryResult},
  * this represents the result to a Boolean/Ask query.  Normally this has been represented as a single primitive
  * boolean result value.  Using a result based object here while inconvenient in some cases is preferable in
  * the cases where you want to treat all result types as the same, that is, now all queries return something

--- a/core/main/src/com/complexible/common/openrdf/query/BooleanQueryResultImpl.java
+++ b/core/main/src/com/complexible/common/openrdf/query/BooleanQueryResultImpl.java
@@ -17,7 +17,7 @@ package com.complexible.common.openrdf.query;
 
 import java.util.NoSuchElementException;
 
-import org.openrdf.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
 
 /**
  * <p>Default implementation of a {@link BooleanQueryResult}</p>

--- a/core/main/src/com/complexible/common/openrdf/query/DelegatingBindingSet.java
+++ b/core/main/src/com/complexible/common/openrdf/query/DelegatingBindingSet.java
@@ -7,9 +7,9 @@ package com.complexible.common.openrdf.query;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.openrdf.model.Value;
-import org.openrdf.query.Binding;
-import org.openrdf.query.BindingSet;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Binding;
+import org.eclipse.rdf4j.query.BindingSet;
 
 /**
  * <p></p>

--- a/core/main/src/com/complexible/common/openrdf/query/DelegatingGraphQueryResult.java
+++ b/core/main/src/com/complexible/common/openrdf/query/DelegatingGraphQueryResult.java
@@ -17,9 +17,9 @@ package com.complexible.common.openrdf.query;
 
 import java.util.Map;
 
-import org.openrdf.query.GraphQueryResult;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.model.Statement;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.model.Statement;
 
 /**
  * <p>Base class for creating a GraphQueryResult decorator which delegates all calls to the child result.</p>

--- a/core/main/src/com/complexible/common/openrdf/query/DelegatingTupleQueryResult.java
+++ b/core/main/src/com/complexible/common/openrdf/query/DelegatingTupleQueryResult.java
@@ -17,9 +17,9 @@ package com.complexible.common.openrdf.query;
 
 import java.util.List;
 
-import org.openrdf.query.TupleQueryResult;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.BindingSet;
 
 /**
  * <p>Base class for creating a TupleQueryResult decorator which delegates all calls to its child TupleQueryResult</p>

--- a/core/main/src/com/complexible/common/openrdf/query/ImmutableBindingSet.java
+++ b/core/main/src/com/complexible/common/openrdf/query/ImmutableBindingSet.java
@@ -20,8 +20,8 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
-import org.openrdf.query.Binding;
-import org.openrdf.query.BindingSet;
+import org.eclipse.rdf4j.query.Binding;
+import org.eclipse.rdf4j.query.BindingSet;
 
 /**
  * <p>An immutable {@link BindingSet}</p>

--- a/core/main/src/com/complexible/common/openrdf/query/ImmutableDataset.java
+++ b/core/main/src/com/complexible/common/openrdf/query/ImmutableDataset.java
@@ -19,8 +19,8 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ObjectArrays;
-import org.openrdf.model.IRI;
-import org.openrdf.query.Dataset;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.query.Dataset;
 
 import java.util.Set;
 

--- a/core/main/src/com/complexible/common/openrdf/query/SesameQueryUtils.java
+++ b/core/main/src/com/complexible/common/openrdf/query/SesameQueryUtils.java
@@ -15,25 +15,25 @@
 
 package com.complexible.common.openrdf.query;
 
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.model.IRI;
-import org.openrdf.model.BNode;
-import org.openrdf.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Literal;
 
-import org.openrdf.model.util.Literals;
-import org.openrdf.query.BindingSet;
+import org.eclipse.rdf4j.model.util.Literals;
+import org.eclipse.rdf4j.query.BindingSet;
 
-import org.openrdf.query.algebra.Slice;
-import org.openrdf.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.Slice;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
 
-import org.openrdf.query.algebra.helpers.AbstractQueryModelVisitor;
-import org.openrdf.query.algebra.helpers.QueryModelVisitorBase;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.eclipse.rdf4j.query.algebra.helpers.QueryModelVisitorBase;
 
-import org.openrdf.query.algebra.ProjectionElem;
+import org.eclipse.rdf4j.query.algebra.ProjectionElem;
 
 import com.google.common.collect.Sets;
-import org.openrdf.query.parser.ParsedQuery;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
 
 import java.util.Collection;
 import java.util.regex.Matcher;
@@ -298,7 +298,7 @@ public final class SesameQueryUtils {
     }
 
 	/**
-     * Implementation of a {@link org.openrdf.query.algebra.QueryModelVisitor} which will set the limit or offset of a query
+     * Implementation of a {@link org.eclipse.rdf4j.query.algebra.QueryModelVisitor} which will set the limit or offset of a query
      * object to the provided value.  If there is no slice operator specified, {@link #limitWasSet} and {@link #offsetWasSet} will return false.
      */
     private static class SliceMutator extends QueryModelVisitorBase<Exception> {

--- a/core/main/src/com/complexible/common/openrdf/repository/ConnectionClosingGraphQueryResult.java
+++ b/core/main/src/com/complexible/common/openrdf/repository/ConnectionClosingGraphQueryResult.java
@@ -17,10 +17,10 @@ package com.complexible.common.openrdf.repository;
 
 import com.complexible.common.openrdf.query.DelegatingGraphQueryResult;
 
-import org.openrdf.query.GraphQueryResult;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
 
 /**
  * <p></p>

--- a/core/main/src/com/complexible/common/openrdf/repository/ConnectionClosingRepositoryResult.java
+++ b/core/main/src/com/complexible/common/openrdf/repository/ConnectionClosingRepositoryResult.java
@@ -15,9 +15,9 @@
 
 package com.complexible.common.openrdf.repository;
 
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 
 /**
  * <p>A {}@link RepositoryResult} which will close the {@link RepositoryConnection} which created it when it's closed.</p>

--- a/core/main/src/com/complexible/common/openrdf/repository/ConnectionClosingTupleQueryResult.java
+++ b/core/main/src/com/complexible/common/openrdf/repository/ConnectionClosingTupleQueryResult.java
@@ -17,10 +17,10 @@ package com.complexible.common.openrdf.repository;
 
 import com.complexible.common.openrdf.query.DelegatingTupleQueryResult;
 
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.TupleQueryResult;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
 
 /**
  * <p></p>

--- a/core/main/src/com/complexible/common/openrdf/repository/Repositories.java
+++ b/core/main/src/com/complexible/common/openrdf/repository/Repositories.java
@@ -28,27 +28,28 @@ import java.io.Writer;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Closeables;
-import info.aduna.iteration.CloseableIteration;
-import info.aduna.iteration.EmptyIteration;
-import org.openrdf.model.Graph;
-import org.openrdf.model.IRI;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.Value;
-import org.openrdf.query.GraphQueryResult;
-import org.openrdf.query.MalformedQueryException;
-import org.openrdf.query.QueryEvaluationException;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.query.TupleQueryResult;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.repository.RepositoryResult;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.rio.RDFHandlerException;
-import org.openrdf.rio.RDFParseException;
-import org.openrdf.rio.RDFWriter;
-import org.openrdf.rio.Rio;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.EmptyIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.GraphQueryResult;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.RepositoryResult;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFWriter;
+import org.eclipse.rdf4j.rio.Rio;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,13 +96,13 @@ public final class Repositories {
 		}
 	}
 
-	public static void add(final Repository theRepository, final Graph theGraph) throws RepositoryException {
+	public static void add(final Repository theRepository, final Model theGraph) throws RepositoryException {
 		try (RepositoryConnection aConn = theRepository.getConnection()) {
 			RepositoryConnections.add(aConn, theGraph);
 		}
 	}
 
-	public static void remove(final Repository theRepository, final Graph theGraph) throws RepositoryException {
+	public static void remove(final Repository theRepository, final Model theGraph) throws RepositoryException {
 		try (RepositoryConnection aConn = theRepository.getConnection()) {
 			RepositoryConnections.remove(aConn, theGraph);
 		}

--- a/core/main/src/com/complexible/common/openrdf/repository/RepositoryConnections.java
+++ b/core/main/src/com/complexible/common/openrdf/repository/RepositoryConnections.java
@@ -22,22 +22,22 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Closeables;
-import org.openrdf.model.Graph;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
-
-import org.openrdf.repository.util.RDFInserter;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.rio.RDFParseException;
-import org.openrdf.rio.RDFParser;
-import org.openrdf.rio.Rio;
-import org.openrdf.rio.helpers.BasicParserSettings;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.util.RDFInserter;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Closeables;
 
 /**
  * <p></p>
@@ -68,7 +68,7 @@ public final class RepositoryConnections {
 		}
 	}
 
-	public static void add(final RepositoryConnection theConnection, final Graph theGraph) throws RepositoryException {
+	public static void add(final RepositoryConnection theConnection, final Model theGraph) throws RepositoryException {
 		try {
 			theConnection.begin();
 			theConnection.add(theGraph);
@@ -80,7 +80,7 @@ public final class RepositoryConnections {
 		}
 	}
 
-	public static void remove(final RepositoryConnection theConnection, final Graph theGraph) throws RepositoryException {
+	public static void remove(final RepositoryConnection theConnection, final Model theGraph) throws RepositoryException {
 		try {
 			theConnection.begin();
 			theConnection.remove(theGraph);

--- a/core/main/src/com/complexible/common/openrdf/sail/SailConnections.java
+++ b/core/main/src/com/complexible/common/openrdf/sail/SailConnections.java
@@ -16,12 +16,14 @@
 package com.complexible.common.openrdf.sail;
 
 import com.complexible.common.openrdf.util.AdunaIterations;
-import info.aduna.iteration.CloseableIteration;
-import org.openrdf.model.Graph;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.sail.SailConnection;
-import org.openrdf.sail.SailException;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.Graph;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.SailException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +56,7 @@ public final class SailConnections {
 		}
 	}
 
-	public static void add(final SailConnection theConnection, final Graph theGraph) throws SailException {
+	public static void add(final SailConnection theConnection, final Model theGraph) throws SailException {
 		try {
 			theConnection.begin();
 			for (Statement aStmt : theGraph) {
@@ -73,7 +75,7 @@ public final class SailConnections {
 		}
 	}
 
-	public static void remove(final SailConnection theConnection, final Graph theGraph) throws SailException {
+	public static void remove(final SailConnection theConnection, final Model theGraph) throws SailException {
 		try {
 			theConnection.begin();
 			for (Statement aStmt : theGraph) {

--- a/core/main/src/com/complexible/common/openrdf/sail/SailConnections.java
+++ b/core/main/src/com/complexible/common/openrdf/sail/SailConnections.java
@@ -15,10 +15,7 @@
 
 package com.complexible.common.openrdf.sail;
 
-import com.complexible.common.openrdf.util.AdunaIterations;
-
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
-import org.eclipse.rdf4j.model.Graph;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -26,6 +23,8 @@ import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.complexible.common.openrdf.util.AdunaIterations;
 
 /**
  * <p></p>

--- a/core/main/src/com/complexible/common/openrdf/sail/Sails.java
+++ b/core/main/src/com/complexible/common/openrdf/sail/Sails.java
@@ -15,13 +15,14 @@
 
 package com.complexible.common.openrdf.sail;
 
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.SailException;
+
 import com.complexible.common.openrdf.util.AdunaIterations;
-import info.aduna.iteration.CloseableIteration;
-import org.openrdf.model.Graph;
-import org.openrdf.model.Statement;
-import org.openrdf.sail.Sail;
-import org.openrdf.sail.SailConnection;
-import org.openrdf.sail.SailException;
 
 /**
  * <p></p>
@@ -46,7 +47,7 @@ public final class Sails {
 		}
 	}
 
-	public static void add(final Sail theSail, final Graph theGraph) throws SailException {
+	public static void add(final Sail theSail, final Model theGraph) throws SailException {
 		SailConnection aConn = theSail.getConnection();
 		try {
 			SailConnections.add(aConn, theGraph);
@@ -56,7 +57,7 @@ public final class Sails {
 		}
 	}
 
-	public static void remove(final Sail theSail, final Graph theGraph) throws SailException {
+	public static void remove(final Sail theSail, final Model theGraph) throws SailException {
 		SailConnection aConn = theSail.getConnection();
 		try {
 			SailConnections.remove(aConn, theGraph);

--- a/core/main/src/com/complexible/common/openrdf/util/AdunaIterations.java
+++ b/core/main/src/com/complexible/common/openrdf/util/AdunaIterations.java
@@ -20,11 +20,11 @@ import java.util.Optional;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
 
-import info.aduna.iteration.CloseableIteration;
-import info.aduna.iteration.Iterations;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.Iterations;
 
 /**
- * <p>Utility methods for Aduna {@link info.aduna.iteration.Iteration Iterations} not already present in {@link Iterations}</p>
+ * <p>Utility methods for Aduna {@link org.eclipse.rdf4j.common.iteration.Iteration Iterations} not already present in {@link Iterations}</p>
  *
  * @author  Michael Grove
  * @since   0.4

--- a/core/main/src/com/complexible/common/openrdf/util/ModelBuilder.java
+++ b/core/main/src/com/complexible/common/openrdf/util/ModelBuilder.java
@@ -16,12 +16,12 @@
 package com.complexible.common.openrdf.util;
 
 import com.complexible.common.openrdf.model.Models2;
-import org.openrdf.model.IRI;
-import org.openrdf.model.Model;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.model.vocabulary.RDF;
-import org.openrdf.model.Resource;
-import org.openrdf.model.ValueFactory;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
 
 /**
  * <p>Utility class for creating a set of statements using {@link ResourceBuilder ResourceBuilders}.</p>

--- a/core/main/src/com/complexible/common/openrdf/util/ModelBuildingRDFHandler.java
+++ b/core/main/src/com/complexible/common/openrdf/util/ModelBuildingRDFHandler.java
@@ -16,10 +16,10 @@
 package com.complexible.common.openrdf.util;
 
 import com.complexible.common.openrdf.model.Models2;
-import org.openrdf.model.Model;
-import org.openrdf.rio.helpers.AbstractRDFHandler;
-import org.openrdf.rio.RDFHandlerException;
-import org.openrdf.model.Statement;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.model.Statement;
 
 /**
  * <p>Implementation of an RDFHandler which collects statements from the handler events and puts them into a Graph object.</p>

--- a/core/main/src/com/complexible/common/openrdf/util/RDFByteSource.java
+++ b/core/main/src/com/complexible/common/openrdf/util/RDFByteSource.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.google.common.io.ByteSource;
-import org.openrdf.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFFormat;
 
 /**
  * <p>A {@link ByteSource} whose contents is RDF serialized in {@link RDFFormat some format}.</p>

--- a/core/main/src/com/complexible/common/openrdf/util/ResourceBuilder.java
+++ b/core/main/src/com/complexible/common/openrdf/util/ResourceBuilder.java
@@ -16,16 +16,16 @@
 package com.complexible.common.openrdf.util;
 
 import com.complexible.common.openrdf.model.Models2;
-import org.openrdf.model.Model;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.model.vocabulary.RDFS;
-import org.openrdf.model.vocabulary.RDF;
-import org.openrdf.model.vocabulary.XMLSchema;
-import org.openrdf.model.Value;
-import org.openrdf.model.IRI;
-import org.openrdf.model.Resource;
-import org.openrdf.model.BNode;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.BNode;
 
 import java.util.List;
 import java.util.Date;

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/DBPedia.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/DBPedia.java
@@ -1,6 +1,6 @@
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * <p>Vocabulary for the DBPedia schemas</p>

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/DC.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/DC.java
@@ -15,7 +15,7 @@
 
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * <p>Term constants for the DC ontology</p>

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/FAO.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/FAO.java
@@ -15,7 +15,7 @@
 
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * <p></p>

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/FOAF.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/FOAF.java
@@ -15,7 +15,7 @@
 
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * <p>Constants for the concepts in the FOAF vocabulary</p>

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/MusicOntology.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/MusicOntology.java
@@ -15,7 +15,7 @@
 
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * <p>Term constants for the DC music ontology</p>

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/SSD.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/SSD.java
@@ -15,7 +15,7 @@
 
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * <p></p>

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/VCard.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/VCard.java
@@ -15,7 +15,7 @@
 
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * <p>Term constants for the VCard ontology</p>

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/Vocabulary.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/Vocabulary.java
@@ -32,7 +32,7 @@ public class Vocabulary {
     private String mURI;
 
     public Vocabulary(String theURI) {
-		this(theURI, ValueFactoryImpl.getInstance());
+		this(theURI, SimpleValueFactory.getInstance());
 	}
 
 	public Vocabulary(String theURI, final ValueFactory theValueFactory) {

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/Vocabulary.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/Vocabulary.java
@@ -15,9 +15,9 @@
 
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.impl.ValueFactoryImpl;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
  * <p>Base class for creating a term factory for an ontology or schema.</p>

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/VoiD.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/VoiD.java
@@ -1,6 +1,6 @@
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * <p></p>

--- a/core/main/src/com/complexible/common/openrdf/vocabulary/WGS.java
+++ b/core/main/src/com/complexible/common/openrdf/vocabulary/WGS.java
@@ -15,7 +15,7 @@
 
 package com.complexible.common.openrdf.vocabulary;
 
-import org.openrdf.model.IRI;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * <p>Term constants for the WGS ontology</p>

--- a/core/test/src/com/complexible/common/openrdf/ConstrainedModelTests.java
+++ b/core/test/src/com/complexible/common/openrdf/ConstrainedModelTests.java
@@ -19,11 +19,11 @@ import java.util.function.Predicate;
 
 import com.complexible.common.openrdf.model.ConstrainedModel;
 import org.junit.Test;
-import org.openrdf.model.BNode;
-import org.openrdf.model.Model;
-import org.openrdf.model.Statement;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 
 import static org.junit.Assert.fail;
 
@@ -52,7 +52,7 @@ public class ConstrainedModelTests {
 		aGraph.addAll(TestUtils.createRandomModel(5));
 
 		try {
-			aGraph.add(SimpleValueFactory.getInstance().createBNode(), RDF.TYPE, SimpleValueFactory.getInstance().createURI("urn:o"));
+			aGraph.add(SimpleValueFactory.getInstance().createBNode(), RDF.TYPE, SimpleValueFactory.getInstance().createIRI("urn:o"));
 			fail("should not allow an addition which violates a constraint");
 		}
 		catch (RuntimeException e) {
@@ -60,7 +60,7 @@ public class ConstrainedModelTests {
 		}
 
 		try {
-			aGraph.add(SimpleValueFactory.getInstance().createURI("urn:s"), RDF.TYPE, SimpleValueFactory.getInstance().createBNode());
+			aGraph.add(SimpleValueFactory.getInstance().createIRI("urn:s"), RDF.TYPE, SimpleValueFactory.getInstance().createBNode());
 			fail("should not allow an addition which violates a constraint");
 		}
 		catch (RuntimeException e) {

--- a/core/test/src/com/complexible/common/openrdf/GraphBuilderTests.java
+++ b/core/test/src/com/complexible/common/openrdf/GraphBuilderTests.java
@@ -23,13 +23,12 @@ import javax.xml.datatype.DatatypeFactory;
 
 import com.complexible.common.openrdf.util.ModelBuilder;
 import org.junit.Test;
-import org.openrdf.model.IRI;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Model;
-import org.openrdf.model.Statement;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.model.impl.ValueFactoryImpl;
-import org.openrdf.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 
 import static org.junit.Assert.assertEquals;
 
@@ -48,7 +47,7 @@ public class GraphBuilderTests {
 
 		final Date aDate = Calendar.getInstance().getTime();
 
-		aBuilder.iri(aURI).addProperty(ValueFactoryImpl.getInstance().createIRI("urn:bar"), aDate);
+		aBuilder.iri(aURI).addProperty(SimpleValueFactory.getInstance().createIRI("urn:bar"), aDate);
 
 		Model aGraph = aBuilder.model();
 

--- a/core/test/src/com/complexible/common/openrdf/ModelIOTests.java
+++ b/core/test/src/com/complexible/common/openrdf/ModelIOTests.java
@@ -18,9 +18,9 @@ package com.complexible.common.openrdf;
 import com.complexible.common.openrdf.model.ModelIO;
 import com.complexible.common.openrdf.model.Models2;
 import org.junit.Test;
-import org.openrdf.model.Model;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.rio.RDFFormat;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
 
 import static org.junit.Assert.assertEquals;
 

--- a/core/test/src/com/complexible/common/openrdf/TestModels2.java
+++ b/core/test/src/com/complexible/common/openrdf/TestModels2.java
@@ -15,34 +15,32 @@
 
 package com.complexible.common.openrdf;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.impl.IteratingGraphQueryResult;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.Test;
+
 import com.complexible.common.openrdf.model.ModelIO;
 import com.complexible.common.openrdf.model.Models2;
 import com.complexible.common.openrdf.model.Statements;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
-import org.openrdf.model.IRI;
-import org.openrdf.model.Literal;
-import org.openrdf.model.Model;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.model.util.Models;
-import org.openrdf.model.vocabulary.RDF;
-import org.openrdf.model.Statement;
-import org.openrdf.model.Resource;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.query.impl.IteratingGraphQueryResult;
-import org.openrdf.rio.RDFFormat;
-
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Set;
 
 /**
  * <p>Tests for Models2</p>

--- a/core/test/src/com/complexible/common/openrdf/TestRepositories.java
+++ b/core/test/src/com/complexible/common/openrdf/TestRepositories.java
@@ -22,13 +22,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import org.openrdf.model.Model;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.model.Statement;
-import org.openrdf.repository.sail.SailRepository;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/core/test/src/com/complexible/common/openrdf/TestUtils.java
+++ b/core/test/src/com/complexible/common/openrdf/TestUtils.java
@@ -17,18 +17,17 @@ package com.complexible.common.openrdf;
 
 import com.complexible.common.openrdf.model.Models2;
 import com.complexible.common.openrdf.repository.Repositories;
-import org.openrdf.model.IRI;
-import org.openrdf.model.Model;
-import org.openrdf.model.impl.SimpleStatement;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.model.Statement;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Value;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.query.parser.sparql.SPARQLParser;
-import org.openrdf.query.parser.ParsedQuery;
-import org.openrdf.query.MalformedQueryException;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.eclipse.rdf4j.query.MalformedQueryException;
 
 import java.util.Random;
 

--- a/core/test/src/com/complexible/common/openrdf/TestUtils.java
+++ b/core/test/src/com/complexible/common/openrdf/TestUtils.java
@@ -15,21 +15,22 @@
 
 package com.complexible.common.openrdf;
 
-import com.complexible.common.openrdf.model.Models2;
-import com.complexible.common.openrdf.repository.Repositories;
+import java.util.Random;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryException;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
-import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryException;
 
-import java.util.Random;
+import com.complexible.common.openrdf.model.Models2;
+import com.complexible.common.openrdf.repository.Repositories;
 
 /**
  * <p></p>
@@ -80,6 +81,6 @@ public final class TestUtils {
 						? SimpleValueFactory.getInstance().createIRI("urn:" + RANDOM.nextLong())
 						: SimpleValueFactory.getInstance().createLiteral(""+ RANDOM.nextLong());
 
-		return new SimpleStatement(aSubj, aPred, aObj);
+				return SimpleValueFactory.getInstance().createStatement(aSubj, aPred, aObj);
 	}
 }

--- a/core/test/src/com/complexible/common/openrdf/query/sparql/TestQueryUtils.java
+++ b/core/test/src/com/complexible/common/openrdf/query/sparql/TestQueryUtils.java
@@ -29,17 +29,17 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.openrdf.model.BNode;
-import org.openrdf.model.Literal;
-import org.openrdf.model.IRI;
-import org.openrdf.model.impl.SimpleValueFactory;
-import org.openrdf.query.QueryEvaluationException;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
 
-import org.openrdf.query.algebra.QueryModelNode;
-import org.openrdf.query.algebra.Slice;
-import org.openrdf.query.algebra.helpers.AbstractQueryModelVisitor;
-import org.openrdf.query.impl.MapBindingSet;
-import org.openrdf.query.parser.ParsedQuery;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.Slice;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+import org.eclipse.rdf4j.query.impl.MapBindingSet;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
 
 /**
  * <p></p>


### PR DESCRIPTION
Mostly namespaces changes as per directions on
http://docs.rdf4j.org/migration/. Other changes are mostly URI-IRI and
Graph-Model related (deprecations).

Two tests still fail. Also note, version number updated because it was
strange to see Pinto depend on a version that does not exist on Github
(4.0.2).

It was also hard to make a decision as to how to name the dependency.
Chose to keep 'sesame' and where needed wrote 'sesameRdf4J' to clarify.